### PR TITLE
Modified hdf5 tests to fix Windows errors from unclosed hdf5 files

### DIFF
--- a/freqdemod/tests/test_freqdemod.py
+++ b/freqdemod/tests/test_freqdemod.py
@@ -60,7 +60,7 @@ class InitLoadSaveTests(unittest.TestCase):
 class TestClose(unittest.TestCase):
     filename = '.TestClose.h5'
     def setUp(self):
-        self.s = Signal(self.filename, backing_store=True)
+        self.s = Signal(self.filename,  mode='w', backing_store=True)
         self.s.load_nparray(np.arange(3),"x","nm",10E-6)
         self.s.close()
 
@@ -94,6 +94,8 @@ class TestClose(unittest.TestCase):
         # test one of the attributes
 
         self.assertTrue(self.snew.f.attrs['source'],'demodulate.py')
+
+        self.snew.close()
 
         
 class MaskTests(unittest.TestCase):


### PR DESCRIPTION
Fixes errors:

    WindowsError: [Error 32] The process cannot access the file because it is being used by another process: '.TestClose.h5'

and

    IOError: .TestClose.h5 already exists. 

(caused by the first error failing to remove the test file.